### PR TITLE
etcd: support one or many ETCD addresses

### DIFF
--- a/ccentral/client.py
+++ b/ccentral/client.py
@@ -11,6 +11,7 @@ import traceback
 import sys
 import etcd
 import ccentral
+import re
 
 _log = logging.getLogger("ccentral")
 
@@ -18,6 +19,9 @@ TTL_DAY = 24 * 60 * 60
 TTL_WEEK = TTL_DAY*7
 VERSION = "0.4.0"
 API_VERSION = "1"
+
+# based on https://stackoverflow.com/a/9531189
+RE_HOST_PORT = r'(?P<http>[[https://]*)?(?P<host>[^:/ ]+).?(?P<port>[0-9]*).*'
 
 
 class IncCounter:
@@ -54,8 +58,13 @@ class EtcdWrapper:
 
     def __init__(self, etcd_c):
         if isinstance(etcd_c, str):
-            self._host, self._port = etcd_c.split(":")
-            self.etcd = etcd.Client(self._host, int(self._port))
+            addrs = ()
+            # etcd addresses might come in form of
+            # "host:port,host2:port2" or "host:port" with or without 'http'
+            for addr in etcd_c.split(','):
+                m = re.search(RE_HOST_PORT, addr)
+                addrs += ((m.group('host'), int(m.group('port'))),)
+            self.etcd = etcd.Client(addrs, allow_reconnect=True)
         else:
             self.etcd = etcd_c
 


### PR DESCRIPTION
```
In [361]:  re.search(RE_HOST_PORT, 'https://foo.com:2379').group('http')
Out[361]: 'https://'

In [362]:  re.search(RE_HOST_PORT, 'http://foo.com:2379').group('http')
Out[362]: 'http://'

In [363]:  re.search(RE_HOST_PORT, 'foo.com:2379').group('http')
Out[363]: ''

In [364]:  re.search(RE_HOST_PORT, 'foo.com:2379').group('host')
Out[364]: 'foo.com'

In [365]:  re.search(RE_HOST_PORT, 'http://foo.com:2379').group('host')
Out[365]: 'foo.com'

In [366]:  re.search(RE_HOST_PORT, 'https://foo.com:2379').group('host')
Out[366]: 'foo.com'

In [367]:  re.search(RE_HOST_PORT, 'https://foo.com:2379').group('port')
Out[367]: '2379'

In [368]:  re.search(RE_HOST_PORT, 'http://foo.com:2379').group('port')
Out[368]: '2379'

In [369]:  re.search(RE_HOST_PORT, 'foo.com:2379').group('port')
Out[369]: '2379'
```

and
```
In [381]: etcd_c = 'foo.com:2379,http://foo.bar.com:2379,https://foo2.bar.com:2379'
In [382]: for addr in etcd_c.split(','):
     ...:     m = re.search(RE_HOST_PORT, addr)
     ...:     addrs += ((m.group('host'), int(m.group('port'))),)
In [383]: addrs
Out[383]: (('foo.com', 2379), ('foo.bar.com', 2379), ('foo2.bar.com', 2379))

In [387]: addrs = ()
In [388]: for addr in etcd_c.split(','):
     ...:     m = re.search(RE_HOST_PORT, addr)
     ...:     addrs += ((m.group('host'), int(m.group('port'))),)
In [389]: addrs
Out[389]: (('foo.com', 2379),)

```